### PR TITLE
fix: Correct import path for isMobileDevice

### DIFF
--- a/src/components/InputSection.tsx
+++ b/src/components/InputSection.tsx
@@ -1,6 +1,6 @@
 import React, { useRef } from 'react';
 import { TextField, Button, Box, Typography, CircularProgress, useTheme } from '@mui/material';
-import { isMobileDevice } from '../utils/isMobileDevice';
+import { isMobileDevice } from '../utils/helpers';
 
 interface InputSectionProps {
   value: string;


### PR DESCRIPTION
This commit fixes a build error caused by an incorrect import path for the `isMobileDevice` utility in the `InputSection.tsx` component.

The import path has been corrected to point to `../utils/helpers` where the utility is actually located.

This ensures that the application builds successfully and the components that rely on this utility function correctly.