### PR TITLE
fix: Correct import paths for utilities

### DIFF
--- a/src/components/ResultsDisplay.test.tsx
+++ b/src/components/ResultsDisplay.test.tsx
@@ -3,11 +3,12 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ResultsDisplay from './ResultsDisplay';
 import { Message, SearchResult } from '../types/chatTypes'; // Assuming types are here
-import * as textProcessingUtils from '../utils/textProcessing'; // For mocking processOutputText
+import * as textProcessingUtils from '../utils/helpers'; // For mocking processOutputText
 
-// Mock the processOutputText utility
-jest.mock('../utils/textProcessing', () => ({
-  processOutputText: jest.fn((text) => <>{text}</>), // Simple mock that returns the text
+// Mock the processOutputText utility from the helpers module
+jest.mock('../utils/helpers', () => ({
+  ...jest.requireActual('../utils/helpers'), // Keep original implementations for other helpers
+  processOutputText: jest.fn((text) => <>{text}</>), // Mock just processOutputText
 }));
 
 const mockProcessOutputText = textProcessingUtils.processOutputText as jest.Mock;

--- a/src/components/ResultsDisplay.tsx
+++ b/src/components/ResultsDisplay.tsx
@@ -11,7 +11,7 @@ import {
   ChatBubbleOutlineOutlined as ChatBubbleOutlineOutlinedIcon, // For empty state
 } from '@mui/icons-material';
 import { SearchResult, Message } from '../types/chatTypes';
-import { processOutputText } from '../utils/textProcessing';
+import { processOutputText } from '../utils/helpers';
 
 interface ResultsDisplayProps {
   isLoading: boolean;


### PR DESCRIPTION
This commit fixes build errors caused by incorrect import paths for the `isMobileDevice` and `processOutputText` utilities.

The import paths have been corrected in the following files:
- `src/components/InputSection.tsx`
- `src/components/ResultsDisplay.tsx`
- `src/components/ResultsDisplay.test.tsx`

All imports now correctly point to `../utils/helpers` where the utilities are located. This ensures that the application builds successfully.